### PR TITLE
Fix word size calculation

### DIFF
--- a/include/pasta/bit_vector/bit_vector.hpp
+++ b/include/pasta/bit_vector/bit_vector.hpp
@@ -361,7 +361,6 @@ public:
    */
   void resize(size_t const size, bool const init_value) noexcept {
     size_t const old_bit_size = bit_size_;
-    size_t const old_size = size_;
     bit_size_ = size;
     size_ = (bit_size_ >> 6) + 1;
     data_.resize(size_);
@@ -372,6 +371,7 @@ public:
       for (size_t i = old_bit_size; i < max_bitwise; ++i) {
         operator[](i) = init_value;
       }
+      size_t const old_size = (old_bit_size + 63) / 64;
       uint64_t const fill_value = init_value ? ~(0ULL) : 0ULL;
       std::fill_n(raw_data_ + old_size, size_ - old_size, fill_value);
     }


### PR DESCRIPTION
Otherwise, each multiple of 64 bits would have a word size of 1 too much. This means that when resizing, the first new word is not initialized with the default value