### PR TITLE
Fix CI builds with ubuntu-latest 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -60,5 +60,8 @@ SpacesInParentheses: 'false'
 SpacesInSquareBrackets: 'false'
 Standard: Cpp11
 UseTab: Never
-
+---
+Language: Json
+BasedOnStyle: llvm
+IndentWidth: '4'
 ...

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -24,5 +24,10 @@ jobs:
       run: cmake --preset=release
     - name: Check C++ Formatting
       run: cmake --build build --target check-clang-format
+    - name: Print C++ Formatting Problems
+      if: failure()
+      run: |
+        find . -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format -i
+        git diff
     - name: Check CMake Formatting
       run: cmake --build build --target check-cmake-format

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -10,7 +10,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        compiler: [{cpp: g++-10, c: gcc-10}]
+        version: [11, 12, 13]
+
+    name: Build (GCC ${{ matrix.version }})
 
     runs-on: ${{ matrix.os }}
 
@@ -23,13 +25,12 @@ jobs:
     - name: Prepare build environment
       run: |
         sudo apt update
-        sudo apt-get install ninja-build gcovr
+        sudo apt-get install ninja-build gcovr cmake gcc-${{ matrix.version }} g++-${{ matrix.version }}
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.version }} ${{ matrix.version }}
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.version }} ${{ matrix.version }}
 
     - name: Configure CMake
       run: cmake --preset=debug -DPASTA_BIT_VECTOR_BUILD_TESTS=On -DPASTA_BIT_VECTOR_COVERAGE_REPORTING=On
-      env:
-        CC: gcc-10
-        CXX: g++-10
 
     - name: Build
       run: cmake --build ${{github.workspace}}/debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if (PROJECT_IS_TOP_LEVEL)
   FetchContent_Declare(
     Format.cmake
     GIT_REPOSITORY https://github.com/TheLartians/Format.cmake
-    GIT_TAG v1.8.1
+    GIT_TAG v1.8.3
   )
   FetchContent_MakeAvailable(Format.cmake)
 

--- a/benchmarks/bit_vector_benchmark.cpp
+++ b/benchmarks/bit_vector_benchmark.cpp
@@ -233,10 +233,8 @@ private:
 
     LOG << LOG_PREFIX << "Finished PaStA bit vector benchmark";
 
-    std::cout << "RESULT "
-              << "algo=" << name << " "
-              << "bit_size=" << bit_size_ << " "
-              << "fill_percentage=" << fill_percentage_ << " "
+    std::cout << "RESULT " << "algo=" << name << " " << "bit_size=" << bit_size_
+              << " " << "fill_percentage=" << fill_percentage_ << " "
               << "bv_construction_time=" << bv_construction_time << " "
 #if defined(DNDEBUG)
               << "bv_construction_mem=" << bv_construction_mem.cur_peak << " "


### PR DESCRIPTION
- gcc10 is no longer available on ubuntu-latest
- ubuntu-latest no longer supports Format.cmake 1.8.1, see https://github.com/TheLartians/Format.cmake/pull/45
- Format.cmake 1.8.3 now tries to format json, which needs changes to the clang-format configuration file
- clang-format no longer likes the line breaks in the result line outputs
- Also, added some debug output when clang-format fails